### PR TITLE
`Sutra.use()` - More granular configurations of sub-sutras

### DIFF
--- a/lib/sutra.js
+++ b/lib/sutra.js
@@ -49,7 +49,78 @@ class Sutra {
     this.nodeIdCounter = 0; // New property to keep track of node IDs
   }
 
-  use(subSutra, name, insertAt = this.tree.length, shareListeners = true) {
+  use(subSutra, name, insertAt = this.tree.length, shareListeners = false, shareTree = true, shareMap = true) {
+
+      /*
+
+        To demonstrate valid use cases for each configuration (`shareListeners`, `shareTree`, `shareMap`):
+
+        ### Example 1: Game Level and Sub-Level Management (`shareTree = true`, `shareListeners = false`, `shareMap = true`)
+
+        In this scenario, a game consists of multiple levels, each with its own set of sub-levels (e.g., stages or challenges within the main level). Sharing the tree structure (`shareTree = true`) allows for a unified hierarchy of levels and sub-levels, while not sharing listeners (`shareListeners = false`) maintains the ability to have level-specific interactions. Sharing maps (`shareMap = true`) can provide shared configurations or metadata across levels and sub-levels.
+
+        ```javascript
+        // Main game level setup
+        let mainLevel = createSutra('MainLevel');
+        mainLevel.on('start', () => console.log('Main level started'));
+        mainLevel.on('complete', () => s('Main level completed'));
+
+        // Sub-level setup (e.g., a puzzle within the main level)
+        let puzzleSubLevel = createSutra('PuzzleSubLevel');
+        puzzleSubLevel.on('start', () => console.log('Puzzle sub-level started'));
+        puzzleSubLevel.on('complete', () => console.log('Puzzle sub-level solved'));
+
+        // Use the sub-level within the main level without sharing listeners but sharing the tree and maps
+        mainLevel.use(puzzleSubLevel, 'Puzzle', mainLevel.tree.length, false, true, true);
+
+        // Shared map might contain metadata like difficulty settings, applicable to both levels
+        mainLevel.maps.difficulty = 'Hard';
+        ```
+
+        ### Example 2: Character and Inventory Management (`shareListeners = true`, `shareTree = true`)
+
+        In this example, a character in the game has an inventory system. Sharing both the tree (`shareTree = true`) and listeners (`shareListeners = true`) allows for the inventory to be seamlessly integrated into the character's event system, enabling interactions between the character and their inventory items.
+
+        ```javascript
+        // Character setup
+        let character = createSutra('Character');
+        character.on('pickUp', (item) => console.log(`Character picked up ${item}`));
+        character.on('useItem', (item) => console.log(`Character used ${item}`));
+
+        // Inventory setup
+        let inventory = createSutra('Inventory');
+        inventory.on('addItem', (item) => console.log(`Item ${item} added to inventory`));
+        inventory.on('removeItem', (item) => console.log(`Item ${item} removed from inventory`));
+
+        // Integrate inventory into character, sharing both tree and listeners
+        character.use(inventory, 'CharacterInventory', character.tree.length, true, true);
+
+        // Now, events like 'addItem' can trigger both character and inventory listeners
+        character.emit('addItem', 'Sword'); // Character picks up Sword, and it's added to inventory
+        ```
+
+        ### Example 3: Game World and Area-Specific Mechanics (`shareTree = true`, `shareListeners = false`, `shareMap = false`)
+
+        This example involves a game world with distinct areas, each with unique mechanics. Sharing the tree structure (`shareTree = true`) allows for a unified representation of the game world, while not sharing listeners or maps (`shareListeners = false`, `shareMap = false`) keeps area-specific mechanics and configurations independent.
+
+        ```javascript
+        // Game world setup
+        let gameWorld = createSutra('GameWorld');
+        gameWorld.on('enterArea', (area) => console.log(`Entered ${area}`));
+
+        // Specific area with unique mechanics
+        let lavaZone = createSutra('LavaZone');
+        lavaZone.on('heatDamage', () => console.log('Player takes heat damage in Lava Zone'));
+
+        // Use lava zone in the game world, sharing only the tree structure
+        gameWorld.use(lavaZone, 'LavaZone', gameWorld.tree.length, false, true, false);
+
+        // Player entering Lava Zone triggers only the 'enterArea' event from the game world
+        gameWorld.emit('enterArea', 'Lava Zone');
+        ```
+        */
+
+
     // Store a reference to the subSutra for subtree-specific logic
     this.subtrees = this.subtrees || {};
     subSutra.isSubtree = true;
@@ -63,10 +134,32 @@ class Sutra {
       this.listeners = { ...this.listeners, ...subSutra.listeners };
       this.anyListeners = [...(this.anyListeners || []), ...(subSutra.anyListeners || [])];
 
-      // Optionally, update the subtree's listeners to reflect this change
       // This ensures that both the subtree and main tree have the same set of listeners
       subSutra.listeners = this.listeners;
       subSutra.anyListeners = this.anyListeners;
+    }
+
+    if (shareTree) {
+      this.sharedTree = true;
+      // Merge subtree's tree into the main tree
+      this.tree = [...this.tree.slice(0, insertAt), ...subSutra.tree, ...this.tree.slice(insertAt)];
+      // Update sutraPath for all nodes in the subtree
+      // Remark: Is re-generating the paths required, wanted, or needed?
+      /*
+      subSutra.tree.forEach((node, index) => {
+        this.generateSutraPath(node, 'tree', insertAt + index, null);
+      });
+      */
+    }
+
+    if (shareMap) {
+      this.sharedMap = true;
+
+      // Merge subtree's maps into the main tree's maps
+      this.maps = { ...this.maps, ...subSutra.maps };
+
+      // Update the subtree's maps to reflect this change
+      // subSutra.maps = this.maps;
     }
 
     // Integrate conditions from the subSutra
@@ -153,7 +246,6 @@ class Sutra {
     }
     return this; // Return this for chaining
   }
-
 
   then(actionOrFunction, data = null) {
     const lastNode = this.tree[this.tree.length - 1];
@@ -245,7 +337,6 @@ class Sutra {
         actionNode.sutraPath = `${lastNode.sutraPath}.then[${lastNode.then.length}]`;
 
         lastNode.then.push(actionNode);
-  
       }
     }
 

--- a/test/sutra-event-emitter-test.js
+++ b/test/sutra-event-emitter-test.js
@@ -55,7 +55,7 @@ tap.test('Subtree Event Emission with Shared Listeners', (t) => {
   const mainSutra = new Sutra();
   const subSutra = createBasicSutra();
 
-  mainSutra.use(subSutra, 'subtree'); // Share listeners
+  mainSutra.use(subSutra, 'subtree', 0, true); // Share listeners
 
   let eventEmittedInSubtree = false;
   subSutra.on('entity::updateEntity', () => {
@@ -70,14 +70,15 @@ tap.test('Subtree Event Emission with Shared Listeners', (t) => {
 
   subSutra.tick({ type: 'BOSS', health: 30 });
 });
-
 tap.test('Event Emission from Main Sutra to Subtree Listener', (t) => {
   const mainSutra = new Sutra();
   const subSutra = createBasicSutra();
 
   // Use the subtree with shared listeners
-  mainSutra.use(subSutra, 'subtree', true);
-
+  mainSutra.use(subSutra, 'subtree', false, true);
+  // TODO: needs new test for double event if both tree and listeners are shared
+  // Remark: in most cases you should *not* need to ever share both, throw / warn might be wise
+  // mainSutra.use(subSutra, 'subtree', true, true);
   // Add a listener in the subtree
   subSutra.on('main::customEvent', () => {
     t.pass('Subtree listener caught event emitted from main Sutra');


### PR DESCRIPTION
  - Adds configurable `shareTree` option
  - Adds configurable `shareMap` option 
  - Adds documentation for each configuration use-case
  - Updates event emitter tests for new defaults
  - **Shared trees are default on**
  - **Shared listeners are now default off**